### PR TITLE
Nextcloud docker for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
     | `DB_VOLUME`              | Location of DB Volume. If left empty the data will only be saved in the docker volume and will not be mapped to a local folder (increases first startup time) | **No**       | `./data/db` for mapping to local folder        |
     | `DB_PORT`                | Local Port that the Postgres DB can be accessed on (outside the container)                                                                                    | **Yes**      | `5432`                                         |
     | `WEB_PORT`               | Local Port used for the website                                                                                                                               | **Yes**      | `8000`                                         | 
-    | `NEXTCLOUD_PORT`         | Local Port that the Nextcloud can be accessed on                                                                                                              | **No**       | `8080`, is only required for Nextcloud testing | 
+    | `NC_PORT`         | Local Port that the Nextcloud can be accessed on                                                                                                              | **No**       | `8080`, only required for Nextcloud testing | 
+    | `NC_USER`         | User for the Nextcloud instance                                                                                                                               | **No**       | Nextcloud User                                        |
+    | `NC_PASSWORD`     | Password for the Nextcloud instance                                                                                                                           | **No**       | Nextcloud password                                |
 
 The easiest way is to create a local `.env` file in the root directory of the project with the following content:
 ```.env
@@ -26,7 +28,9 @@ DB_VOLUME=./data/db
 DEBUG=True
 DB_PORT=5432
 WEB_PORT=8000
-NEXTCLOUD_PORT=8080
+NC_PORT=8080
+NC_USER=<user>
+NC_PASSWORD=<password>
 ```
 
 ## Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
     profiles:
       - test
     environment:
-      NEXTCLOUD_ADMIN_USER: ${NC_AUTH_USER}
-      NEXTCLOUD_ADMIN_PASSWORD: ${NC_AUTH_PASSWORD}
+      NEXTCLOUD_ADMIN_USER: ${NC_USER}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NC_PASSWORD}
     ports:
-      - "${NEXTCLOUD_PORT}:80"
+      - "${NC_PORT}:80"
     volumes:
       - type: tmpfs
         target: /var/www/html

--- a/nextcloud/nextcloud_manager.py
+++ b/nextcloud/nextcloud_manager.py
@@ -8,8 +8,8 @@ Functions:
 
 Environment Variables:
     - NC_URL: The URL of the Nextcloud server
-    - NC_AUTH_USER: The username to authenticate with
-    - NC_AUTH_PASSWORD: The password to authenticate with
+    - NC_USER: The username to authenticate with
+    - NC_PASSWORD: The password to authenticate with
 """
 
 import os
@@ -29,8 +29,8 @@ def initialize_connection() -> None:
     global nc
     load_dotenv()
     nc_url = os.getenv("NC_URL")
-    nc_auth_user = os.getenv("NC_AUTH_USER")
-    nc_auth_pass = os.getenv("NC_AUTH_PASSWORD")
+    nc_auth_user = os.getenv("NC_USER")
+    nc_auth_pass = os.getenv("NC_PASSWORD")
 
     nc = Nextcloud(
         nextcloud_url=nc_url, nc_auth_user=nc_auth_user, nc_auth_pass=nc_auth_pass


### PR DESCRIPTION
Adds a simple non-persisting Nextcloud docker to the docker-compose that can be used for testing. Also provides a sample implementation for a Nextcloud Python manager using an existing library