### PR TITLE
ci: Fix CI not failing when files are not properly formatted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-      # Update output format to enable automatic inline annotations.
-      - name: Check python code formatting with Run Ruff
+      - name: Check python code formatting
+        run: ruff format --check
+      - name: Check for python lints
         run: ruff check --output-format=github .
-      - name: Check Django template formatting with djLint
+      - name: Check Django template formatting
         run: djlint . --check
       - name: Check for typos
         uses: crate-ci/typos@v1.27.2


### PR DESCRIPTION
This fixes an issue where our CI would not actually check if python files were correctly formatted. `ruff check` is only used to check for python lints