### PR TITLE
Configure django logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ data
 .ruff_cache
 .zed
 .DS_Store
+app.log

--- a/TURMFrontend/settings.py
+++ b/TURMFrontend/settings.py
@@ -156,41 +156,41 @@ STATICFILES_DIRS.append(BASE_DIR / "static")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
-            'style': '{',
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
+            "style": "{",
         },
-        'simple': {
-            'format': '{levelname} {message}',
-            'style': '{',
-        },
-    },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'simple',
-        },
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': os.path.join(BASE_DIR, 'app.log'),
-            'formatter': 'verbose',
+        "simple": {
+            "format": "{levelname} {message}",
+            "style": "{",
         },
     },
-    'loggers': {
-        'root': {
-            'handlers': ['console', 'file'],
-            'level': 'DEBUG',
-            'propagate': True,
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
         },
-        'django': {
-            'handlers': ['console', 'file'],
-            'level': 'INFO',
-            'propagate': True,
+        "file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": os.path.join(BASE_DIR, "app.log"),
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        "root": {
+            "handlers": ["console", "file"],
+            "level": "DEBUG",
+            "propagate": True,
+        },
+        "django": {
+            "handlers": ["console", "file"],
+            "level": "INFO",
+            "propagate": True,
         },
     },
 }

--- a/TURMFrontend/settings.py
+++ b/TURMFrontend/settings.py
@@ -154,3 +154,43 @@ STATICFILES_DIRS.append(BASE_DIR / "static")
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
+            'style': '{',
+        },
+        'simple': {
+            'format': '{levelname} {message}',
+            'style': '{',
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
+        },
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'app.log'),
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        'root': {
+            'handlers': ['console', 'file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'django': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,3 +1,4 @@
+import logging
 import django.contrib.auth as auth
 from django import forms
 from django.contrib.auth.decorators import user_passes_test
@@ -11,6 +12,7 @@ import os
 
 from .models import InvitationToken, generate_invitation_link
 
+logger = logging.getLogger(__name__)
 
 class LoginForm(forms.Form):
     email = forms.EmailField(widget=forms.TextInput(attrs={"placeholder": "Email"}))
@@ -55,6 +57,7 @@ def login_user(request):
             request, form=LoginForm(), error="Invalid username or password"
         )
     auth.login(request, user)
+    logger.info(f"User {username} logged in successfully")
     return redirect(settings.LOGIN_REDIRECT_URL)
 
 
@@ -80,6 +83,7 @@ def generate_user_invitation(request):
         return generate_invitation_template(
             request, form=GenerateInvitationForm(), error="Email already registered"
         )
+    logger.info(f"Invitation generated for email {email} by {request.user.username}")
     return generate_invitation_template(request, link=link)
 
 
@@ -120,6 +124,7 @@ def register_user(request, token):
     user.save()
     invitation.save()
     auth.login(request, user)
+    logger.info(f"Created new account for {user.username}")
     return redirect(settings.LOGIN_REDIRECT_URL)
 
 

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -14,6 +14,7 @@ from .models import InvitationToken, generate_invitation_link
 
 logger = logging.getLogger(__name__)
 
+
 class LoginForm(forms.Form):
     email = forms.EmailField(widget=forms.TextInput(attrs={"placeholder": "Email"}))
     password = forms.CharField(


### PR DESCRIPTION
This enables us to use logging throughout the application. I added some log statements where it makes sense (and mostly for testing), i'm sure there are a lot more places we actually want to log something (but that's not what the PR is about).

Current setup will log everything where `level >= DEBUG` to both the console and an `app.log` file.
One exception is that logs from django itself will only be logged when `level >= INFO`, otherwise the log is way to noisy and not helpful

To log something you have to do something like this:

```python
# Get the logger for a module and store it
logger = logging.getLogger(__name__)

# Actually log something
logger.info("This is a log message!")
```
