### PR TITLE
UI Design Generate Invite page and Register page

### DIFF
--- a/authentication/templates/authentication/generate_invitation.html
+++ b/authentication/templates/authentication/generate_invitation.html
@@ -1,116 +1,45 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Authentication Example</title>
-        <style>
-            body {
-                font-family: Arial, sans-serif;
-                text-align: center;
-                padding: 20px;
-            }
-            img {
-                max-width: 100%;
-                height: auto;
-                margin-top: 20px;
-            }
-            .button-container {
-                margin-top: 20px;
-            }
-            button {
-                padding: 10px 20px;
-                font-size: 16px;
-                margin: 10px;
-                cursor: pointer;
-                border: none;
-                background-color: #4caf50;
-                color: white;
-                border-radius: 5px;
-            }
-            button:hover {
-                background-color: #45a049;
-            }
-
-            /* Modal (hidden by default) */
-            .modal {
-                display: none;
-                position: fixed;
-                z-index: 1;
-                left: 0;
-                top: 0;
-                width: 100%;
-                height: 100%;
-                overflow: auto;
-                background-color: rgba(0, 0, 0, 0.4);
-                padding-top: 60px;
-            }
-
-            /* Modal Content */
-            .modal-content {
-                background-color: #fff;
-                margin: 5% auto;
-                padding: 20px;
-                border: 1px solid #888;
-                width: 80%;
-                max-width: 400px;
-                border-radius: 8px;
-                text-align: center;
-            }
-
-            /* Modal success style */
-            .modal-success {
-                background-color: #4caf50;
-                color: white;
-            }
-
-            /* Modal error style */
-            .modal-error {
-                background-color: #f44336;
-                color: white;
-            }
-
-            /* Close button */
-            .close {
-                color: white;
-                font-size: 28px;
-                font-weight: bold;
-                position: absolute;
-                top: 5px;
-                right: 10px;
-                background: none;
-                border: none;
-            }
-        </style>
-    </head>
-    <body>
-        <div style="position: absolute; top: 10px; left: 10px">
-            <button onclick="window.location.href='/'">Home</button>
+{% extends "base_template.html" %}
+{% load static %}
+{% block title %}Generate Invitation Link{% endblock %}
+{% block style %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="{% static "/css/generate_invitation.css" %}">
+ 
+{% endblock %}
+{% block content %}
+    <div class= "outer">
+        <div class= "wrapper">
+            <h1>Generate Invitation Link</h1>
+            {% if error is not None %}<p style="color: red">{{ error }}</p>{% endif %}
+            {% if link is None %}
+            <form method="post" action="{% url 'generate-user-invitation' %}">
+                {% csrf_token %}
+                <div class= "input-field">
+                    <label for="email">Email:</label>
+                    {{ form.email }}
+                    <i class='bx bxs-user'></i>
+                </div>
+                <button class= "generatebutton" type="submit">Generate</button>
+            </form>
+            {% else %}
+                <p id="invitationLink">{{ link }}</p>
+                <button onclick="copyLink()">Copy Link</button>
+                <script>
+                    function copyLink() {
+                        var linkText =
+                            document.getElementById("invitationLink").textContent;
+                        navigator.clipboard.writeText(linkText).then(
+                            function () {
+                                alert("Link copied to clipboard!");
+                            },
+                            function (err) {
+                                alert("Could not copy text: ", err);
+                            },
+                        );
+                    }
+                </script>
+            {% endif %}
         </div>
-        <h1>Generate Invitation Link</h1>
-        {% if error is not None %}<p style="color: red">{{ error }}</p>{% endif %}
-        <form method="post" action="{% url 'generate-user-invitation' %}">
-            {% csrf_token %}
-            {{ form.as_p }}
-            <button type="submit">Generate</button>
-        </form>
-        {% if link is not None %}
-            <p id="invitationLink">{{ link }}</p>
-            <button onclick="copyLink()">Copy Link</button>
-            <script>
-                function copyLink() {
-                    var linkText =
-                        document.getElementById("invitationLink").textContent;
-                    navigator.clipboard.writeText(linkText).then(
-                        function () {
-                            alert("Link copied to clipboard!");
-                        },
-                        function (err) {
-                            alert("Could not copy text: ", err);
-                        },
-                    );
-                }
-            </script>
-        {% endif %}
-    </body>
-</html>
+    </div>
+{% endblock content %}

--- a/authentication/templates/authentication/generate_invitation.html
+++ b/authentication/templates/authentication/generate_invitation.html
@@ -5,8 +5,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="{% static "/css/generate_invitation.css" %}">
-    <link rel='stylesheet' href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css'>
- 
+    <link rel='stylesheet'
+          href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css'>
 {% endblock %}
 {% block content %}
     <div class= "outer">
@@ -14,14 +14,14 @@
             <h1>Generate Invitation Link</h1>
             {% if error is not None %}<p class="error">{{ error }}</p>{% endif %}
             {% if link is None %}
-            <form method="post" action="{% url 'generate-user-invitation' %}">
-                {% csrf_token %}
-                <div class= "input-field">
-                    {{ form.email }}
-                    <i class="bx bx-envelope"></i>
-                </div>
-                <button class= "generatebutton" type="submit">Generate</button>
-            </form>
+                <form method="post" action="{% url 'generate-user-invitation' %}">
+                    {% csrf_token %}
+                    <div class= "input-field">
+                        {{ form.email }}
+                        <i class="bx bx-envelope"></i>
+                    </div>
+                    <button class= "generatebutton" type="submit">Generate</button>
+                </form>
             {% else %}
                 <p id="invitationLink">{{ link }}</p>
                 <button class= "copybutton" onclick="copyLink()">Copy Link</button>

--- a/authentication/templates/authentication/generate_invitation.html
+++ b/authentication/templates/authentication/generate_invitation.html
@@ -5,26 +5,26 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="{% static "/css/generate_invitation.css" %}">
+    <link rel='stylesheet' href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css'>
  
 {% endblock %}
 {% block content %}
     <div class= "outer">
         <div class= "wrapper">
             <h1>Generate Invitation Link</h1>
-            {% if error is not None %}<p style="color: red">{{ error }}</p>{% endif %}
+            {% if error is not None %}<p class="error">{{ error }}</p>{% endif %}
             {% if link is None %}
             <form method="post" action="{% url 'generate-user-invitation' %}">
                 {% csrf_token %}
                 <div class= "input-field">
-                    <label for="email">Email:</label>
                     {{ form.email }}
-                    <i class='bx bxs-user'></i>
+                    <i class="bx bx-envelope"></i>
                 </div>
                 <button class= "generatebutton" type="submit">Generate</button>
             </form>
             {% else %}
                 <p id="invitationLink">{{ link }}</p>
-                <button onclick="copyLink()">Copy Link</button>
+                <button class= "copybutton" onclick="copyLink()">Copy Link</button>
                 <script>
                     function copyLink() {
                         var linkText =

--- a/authentication/templates/authentication/register_from_invitation.html
+++ b/authentication/templates/authentication/register_from_invitation.html
@@ -25,11 +25,11 @@
                         {% csrf_token %}
                         <div class="input-field">
                             {{ form.new_password1 }}
-                            <i class='bx bxs-lock-open-alt' ></i>
+                            <i class='bx bxs-lock-open-alt'></i>
                         </div>
                         <div class="input-field">
                             {{ form.new_password2 }}
-                            <i class='bx bxs-lock-alt' ></i>
+                            <i class='bx bxs-lock-alt'></i>
                         </div>
                         <button type="submit" class= "btn">Register</button>
                     </form>

--- a/authentication/templates/authentication/register_from_invitation.html
+++ b/authentication/templates/authentication/register_from_invitation.html
@@ -13,28 +13,25 @@
     <body>
         <div class= "wrapper">
             <h1>Create account</h1>
-            {% if error %}
-                <p style="color: red">Invalid invitation link</p>
-            {% else %}
-                <div class= "wrapper-body">
-                    <div class= "given-email">
-                        <p>Email: {{ email }}</p>
-                        <box-icon type='solid' name='user'></box-icon>
-                    </div>
-                    <form method="post" action="{% url 'signup' token %}">
-                        {% csrf_token %}
-                        <div class="input-field">
-                            {{ form.new_password1 }}
-                            <i class='bx bxs-lock-open-alt'></i>
-                        </div>
-                        <div class="input-field">
-                            {{ form.new_password2 }}
-                            <i class='bx bxs-lock-alt'></i>
-                        </div>
-                        <button type="submit" class= "btn">Register</button>
-                    </form>
+            <div class= "wrapper-body">
+                <div class= "given-email">
+                    <p>Email: {{ email }}</p>
+                    <box-icon type='solid' name='user'></box-icon>
                 </div>
-            {% endif %}
+                <form method="post" action="{% url 'signup' token %}">
+                    {% csrf_token %}
+                    <div class="input-field">
+                        {{ form.new_password1 }}
+                        <i class='bx bxs-lock-open-alt'></i>
+                    </div>
+                    <div class="input-field">
+                        {{ form.new_password2 }}
+                        <i class='bx bxs-lock-alt'></i>
+                    </div>
+                    {% if error %}<p class="error-message">{{ error }}</p>{% endif %}
+                    <button type="submit" class= "btn">Register</button>
+                </form>
+            </div>
         </div>
     </body>
 </html>

--- a/authentication/templates/authentication/register_from_invitation.html
+++ b/authentication/templates/authentication/register_from_invitation.html
@@ -1,104 +1,40 @@
 <!DOCTYPE html>
 <html lang="en">
+    {% load static %}
     <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Authentication Example</title>
-        <style>
-            body {
-                font-family: Arial, sans-serif;
-                text-align: center;
-                padding: 20px;
-            }
-            img {
-                max-width: 100%;
-                height: auto;
-                margin-top: 20px;
-            }
-            .button-container {
-                margin-top: 20px;
-            }
-            button {
-                padding: 10px 20px;
-                font-size: 16px;
-                margin: 10px;
-                cursor: pointer;
-                border: none;
-                background-color: #4caf50;
-                color: white;
-                border-radius: 5px;
-            }
-            button:hover {
-                background-color: #45a049;
-            }
-
-            /* Modal (hidden by default) */
-            .modal {
-                display: none;
-                position: fixed;
-                z-index: 1;
-                left: 0;
-                top: 0;
-                width: 100%;
-                height: 100%;
-                overflow: auto;
-                background-color: rgba(0, 0, 0, 0.4);
-                padding-top: 60px;
-            }
-
-            /* Modal Content */
-            .modal-content {
-                background-color: #fff;
-                margin: 5% auto;
-                padding: 20px;
-                border: 1px solid #888;
-                width: 80%;
-                max-width: 400px;
-                border-radius: 8px;
-                text-align: center;
-            }
-
-            /* Modal success style */
-            .modal-success {
-                background-color: #4caf50;
-                color: white;
-            }
-
-            /* Modal error style */
-            .modal-error {
-                background-color: #f44336;
-                color: white;
-            }
-
-            /* Close button */
-            .close {
-                color: white;
-                font-size: 28px;
-                font-weight: bold;
-                position: absolute;
-                top: 5px;
-                right: 10px;
-                background: none;
-                border: none;
-            }
-        </style>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>TURM Login</title>
+        <link rel="stylesheet" href="{% static "/css/register_from_invitation.css" %}">
+        <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css'
+              rel='stylesheet'>
     </head>
     <body>
-        <div style="position: absolute; top: 10px; left: 10px">
-            <button onclick="window.location.href='/'">Home</button>
+        <div class= "wrapper">
+            <h1>Create account</h1>
+            {% if error %}
+                <p style="color: red">Invalid invitation link</p>
+            {% else %}
+                <div class= "wrapper-body">
+                    <div class= "given-email">
+                        <p>Email: {{ email }}</p>
+                        <box-icon type='solid' name='user'></box-icon>
+                    </div>
+                    <form method="post" action="{% url 'signup' token %}">
+                        {% csrf_token %}
+                        <div class="input-field">
+                            {{ form.new_password1 }}
+                            <i class='bx bxs-lock-open-alt' ></i>
+                        </div>
+                        <div class="input-field">
+                            {{ form.new_password2 }}
+                            <i class='bx bxs-lock-alt' ></i>
+                        </div>
+                        <button type="submit" class= "btn">Register</button>
+                    </form>
+                </div>
+            {% endif %}
         </div>
-        <h1>Create account</h1>
-        {% if error %}
-            <p style="color: red">Invalid invitation link</p>
-        {% else %}
-            <div>
-                <form method="post" action="{% url 'signup' token %}">
-                    {% csrf_token %}
-                    <p>Email: {{ email }}</p>
-                    {{ form.as_p }}
-                    <button type="submit">Set Password and Register</button>
-                </form>
-            </div>
-        {% endif %}
     </body>
 </html>

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -38,6 +38,7 @@ class SetPasswordForm(forms.Form):
             raise forms.ValidationError("Passwords do not match")
         return cleaned_data
 
+
 @require_GET
 @login_not_required
 def login(request):

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -127,7 +127,11 @@ def register_user(request, token):
     form = SetPasswordForm(request.POST)
     if not form.is_valid():
         return register_from_invitation_template(
-            request, token, error="Invalid password"
+            request,
+            token,
+            form=SetPasswordForm(),
+            email=invitation.email,
+            error="Invalid password",
         )
 
     invitation.delete()

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -20,7 +20,7 @@ class LoginForm(forms.Form):
 
 
 class GenerateInvitationForm(forms.Form):
-    email = forms.EmailField()
+    email = forms.EmailField(widget=forms.TextInput(attrs={"placeholder": "Email"}))
 
 
 @require_GET

--- a/static/css/base_template.css
+++ b/static/css/base_template.css
@@ -28,3 +28,4 @@
     /*font-family: 'Source Sans Pro', sans-serif;*/
     font-family: 'Roboto Light', sans-serif;
 }
+

--- a/static/css/generate_invitation.css
+++ b/static/css/generate_invitation.css
@@ -1,6 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap");
 @import "base_template.css";
-
 
 .outer {
     display: flex;
@@ -8,7 +6,7 @@
     align-items: center;
 }
 
-.wrapper{
+.wrapper {
     width: 450px;
     border-radius: 20px;
     padding: 30px 40px;
@@ -36,7 +34,7 @@
     background-color: var(--tom-primary-color-dark);
 }
 
-.wrapper .input-field{
+.wrapper .input-field {
     color: #fff;
     position: relative;
     margin-bottom: 20px;
@@ -60,12 +58,12 @@
     font-size: 20px;
 }
 
-input {
+.input-field input {
     border-radius: 10px;
     padding: 10px;
     width: 100%;
+    border: none;
     color: black;
-    font: "Poppins", sans-serif;
     font-size: 14px;
 }
 
@@ -84,4 +82,3 @@ input {
     margin-bottom: 20px;
     font-size: 14px;
 }
-

--- a/static/css/generate_invitation.css
+++ b/static/css/generate_invitation.css
@@ -1,0 +1,86 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap");
+@import url("css/base_template.css");
+
+body {
+    font-family: "Poppins", sans-serif;
+    text-align: center;
+    padding: 20px;
+}
+
+.outer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.wrapper{
+    border-radius: 20px;
+    padding: 30px 40px;
+    margin-top: 20px;
+}
+
+.wrapper h1 {
+    font-size: px;
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.button-container {
+    margin-top: 20px;
+}
+button {
+    padding: 10px 20px;
+    font-size: 16px;
+    margin: 10px;
+    cursor: pointer;
+    border: none;
+    background-color: #4caf50;
+    color: white;
+    border-radius: 5px;
+}
+button:hover {
+    background-color: #45a049;
+}
+
+.generatebutton{
+    background-color: var(--tom-primary-color);
+}
+
+.generatebutton:hover{
+    background-color: var(--tom-primary-color-dark);
+}
+
+.wrapper .input-field{
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 10px;
+    color: #fff;
+}
+
+.input-field label{
+    position: absolute;
+    color: grey;
+    font-size: 16px;
+
+
+}
+
+input {
+    border-radius: 10px;
+    padding: 10px;
+    width: 70%;
+    color: black;
+    font: "Poppins", sans-serif;
+    font-size: 14px;
+}
+
+#invitationLink {
+    margin: 20px auto;
+    text-align: center;
+    display: block;
+    font-size: 16px;
+    color: #fff;
+}
+
+

--- a/static/css/generate_invitation.css
+++ b/static/css/generate_invitation.css
@@ -14,6 +14,7 @@ body {
 }
 
 .wrapper{
+    width: 450px;
     border-radius: 20px;
     padding: 30px 40px;
     margin-top: 20px;
@@ -25,51 +26,49 @@ body {
     margin-bottom: 40px;
 }
 
-.button-container {
-    margin-top: 20px;
-}
 button {
     padding: 10px 20px;
     font-size: 16px;
     margin: 10px;
     cursor: pointer;
     border: none;
-    background-color: #4caf50;
+    background-color: var(--tom-primary-color);
     color: white;
     border-radius: 5px;
 }
+
 button:hover {
-    background-color: #45a049;
-}
-
-.generatebutton{
-    background-color: var(--tom-primary-color);
-}
-
-.generatebutton:hover{
     background-color: var(--tom-primary-color-dark);
 }
 
 .wrapper .input-field{
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    left: 10px;
     color: #fff;
+    position: relative;
+    margin-bottom: 20px;
 }
 
-.input-field label{
+.input-field label {
+    font-size: 18px;
+    color: var(--tom-light-grey);
+    padding: 4px;
+    pointer-events: none;
+    padding: 10px;
+    transition: 0.5s;
+}
+
+.input-field i {
     position: absolute;
-    color: grey;
-    font-size: 16px;
-
-
+    right: 20px;
+    top: 50%;
+    color: var(--tom-light-grey);
+    transform: translateY(-50%);
+    font-size: 20px;
 }
 
 input {
     border-radius: 10px;
     padding: 10px;
-    width: 70%;
+    width: 100%;
     color: black;
     font: "Poppins", sans-serif;
     font-size: 14px;
@@ -83,4 +82,11 @@ input {
     color: #fff;
 }
 
+.error-message {
+    color: #e74c3c;
+    margin-left: 10px;
+    margin-top: -10px;
+    margin-bottom: 20px;
+    font-size: 14px;
+}
 

--- a/static/css/generate_invitation.css
+++ b/static/css/generate_invitation.css
@@ -1,11 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap");
-@import url("css/base_template.css");
+@import "base_template.css";
 
-body {
-    font-family: "Poppins", sans-serif;
-    text-align: center;
-    padding: 20px;
-}
 
 .outer {
     display: flex;
@@ -26,7 +21,7 @@ body {
     margin-bottom: 40px;
 }
 
-button {
+.wrapper button {
     padding: 10px 20px;
     font-size: 16px;
     margin: 10px;
@@ -37,7 +32,7 @@ button {
     border-radius: 5px;
 }
 
-button:hover {
+.wrapper button:hover {
     background-color: var(--tom-primary-color-dark);
 }
 

--- a/static/css/register_from_invitation.css
+++ b/static/css/register_from_invitation.css
@@ -18,7 +18,6 @@ body {
     background-position: bottom center;
 }
 
-
 .wrapper {
     width: 420px;
     border: 2px solid rgba(255, 255, 255, 0.2);
@@ -39,7 +38,7 @@ body {
 }
 
 .given-email p {
-    color:  rgba(255, 255, 255, 0.7)
+    color: rgba(255, 255, 255, 0.7);
 }
 
 .wrapper .input-field {
@@ -97,8 +96,7 @@ body {
 
 .error-message {
     color: #e74c3c;
-    margin-left: 10px;
-    margin-top: -10px;
-    margin-bottom: 20px;
+    margin-left: 20px;
+    margin-bottom: 10px;
     font-size: 14px;
 }

--- a/static/css/register_from_invitation.css
+++ b/static/css/register_from_invitation.css
@@ -1,5 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap");
 @import "base_template.css";
+
 * {
     margin: 0;
     padding: 0;
@@ -17,6 +18,7 @@ body {
     background-position: bottom center;
 }
 
+
 .wrapper {
     width: 420px;
     border: 2px solid rgba(255, 255, 255, 0.2);
@@ -29,14 +31,29 @@ body {
 .wrapper h1 {
     font-size: 36px;
     text-align: center;
-    margin-bottom: 40px;
+    margin-bottom: 7px;
+}
+
+.wrapper-body .given-email {
+    margin-left: 20px;
+}
+
+.given-email p {
+    color:  rgba(255, 255, 255, 0.7)
 }
 
 .wrapper .input-field {
     position: relative;
     width: 100%;
     height: 50px;
-    margin: 30px 0;
+    margin: 10px 0;
+}
+
+.given-email {
+    position: relative;
+    color: #fff;
+    font-size: 16px;
+    margin-bottom: 20px;
 }
 
 .input-field input {


### PR DESCRIPTION
I made a basic UI Design for the "generate invite" pages, using the navbar template. I changed the "register from invitation" page, so that the UI Design is cohesive with the login page. Password requirements and edge cases are still missing. 

Generate Invite: 
![image](https://github.com/user-attachments/assets/423236b6-923b-4c0a-b5ce-5b994c45f19d)


Copy Invitation Link:
![image](https://github.com/user-attachments/assets/2b397be9-262d-4a26-b4f8-e32ebfe7712a)

Register from Invitation:
![image](https://github.com/user-attachments/assets/a26b3ccd-8629-4fb0-aa65-694366c73657)
