### PR TITLE
ci: Add `/format` command to trigger formatting on PR

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,32 @@
+name: Auto-format on comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  format:
+    if: github.event.issue.pull_request && github.event.comment.body == '/format'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Run formatting script
+        run: |
+          ./scripts/format.sh
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git commit -m "Apply automatic formatting"
+          git push

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -4,7 +4,7 @@ on:
     types: [created]
 jobs:
   format:
-    if: github.event.issue.pull_request && github.event.comment.body == '/format'
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/format' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -7,11 +7,22 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/format' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get branch name
+        id: branch_name
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.issue.number }},
+            });
+            return pullRequest.head.ref;
+
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ steps.branch_name.outputs.result }}
 
       - name: Run formatting script
         run: |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ To develop the project locally, install the dependencies running both
 
 Run the server using `docker-compose up`.
 
-To format the code, run `scripts/format.sh`.
+Our CI enforces properly formatted code. To format the code, run `scripts/format.sh`.
+Alternatively, you can comment `/format` on any pull request to automatically run the formatting script and commit the changes.
 
 To run the tests, run `python manage.py test` or `docker exec turmfrontend-web python manage.py test` to run the tests inside Docker.
 

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -4,6 +4,5 @@ from dashboard.views import dashboard
 from django.conf import settings
 
 urlpatterns = [
-    path("", 
-        dashboard, name=settings.LOGIN_REDIRECT_URL),
+    path("", dashboard, name=settings.LOGIN_REDIRECT_URL),
 ]

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -4,5 +4,6 @@ from dashboard.views import dashboard
 from django.conf import settings
 
 urlpatterns = [
-    path("", dashboard, name=settings.LOGIN_REDIRECT_URL),
+    path("", 
+        dashboard, name=settings.LOGIN_REDIRECT_URL),
 ]


### PR DESCRIPTION
This PR adds a job that runs our `scripts/format.sh` script and commits the re-formatted file on the PR it was requested on.
The job can be triggered by commenting on a PR with `/format`. This should it make it easier for our Windows users to fix formatting issues when the CI is failing.