### PR TITLE
ci: Install dependencies when running /format action

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
           pip install -r requirements_dev.txt
           npm install --global prettier
 

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -24,6 +24,18 @@ jobs:
         with:
           ref: ${{ steps.branch_name.outputs.result }}
 
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements_dev.txt
+          npm install --global prettier
+
       - name: Run formatting script
         run: |
           ./scripts/format.sh


### PR DESCRIPTION
I forgot to install the necessary dependencies that we need for formatting. This should fix this