### PR TITLE
show multiple error messages

### DIFF
--- a/accounts/templates/accounts/register_from_invitation.html
+++ b/accounts/templates/accounts/register_from_invitation.html
@@ -30,8 +30,8 @@
                         <i class='bx bxs-lock-alt'></i>
                     </div>
                     {% if form.errors %}
-                        {% for error in form.errors.as_data.values %}
-                            {% for error in error.0 %}<div class="error-message">{{ error }}</div>{% endfor %}
+                        {% for error_list in form.errors.values%}
+                            {% for error in error_list%}<div class="error-message">{{ error }}</div>{% endfor %}
                         {% endfor %}
                     {% endif %}
                     <button type="submit" class= "btn">Register</button>

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -184,20 +184,20 @@ class SetPasswordForm(forms.Form):
         cleaned_data = super().clean()
         password1 = cleaned_data.get("new_password1")
         password2 = cleaned_data.get("new_password2")
+        errors = []
+
         if password1 and password2 and password1 != password2:
-            raise forms.ValidationError("The passwords are not the same.")
-        if not is_allowed_password(password1):
-            raise forms.ValidationError(
-                "Only letters, numbers and common special characters are allowed."
-            )
-        if not password_length_ok(password1):
-            raise forms.ValidationError(
-                "Password must be between 8 and 64 characters long."
-            )
-        if not password_requirements_met(password1):
-            raise forms.ValidationError(
-                "Password must contain at least one letter, one number and one special character."
-            )
+            errors.append("The passwords are not the same.")
+        if password1 and not is_allowed_password(password1):
+            errors.append("Only letters, numbers, and common special characters are allowed.")
+        if password1 and not password_length_ok(password1):
+            errors.append("Password must be between 8 and 64 characters long.")
+        if password1 and not password_requirements_met(password1):
+            errors.append("Password must contain at least one letter, one number, and one special character.")
+
+        if errors:
+            raise forms.ValidationError(errors)
+        
         return cleaned_data
 
 


### PR DESCRIPTION
We can now display multiple error messages during password creation, if multiple conditions are not fulfilled. 
![image](https://github.com/user-attachments/assets/81c87bf3-d5ce-428f-9d32-a99f0156da6d)
