### PR TITLE
Add "Cancel" button to new project page

### DIFF
--- a/observation_request/templates/observation_request/create_observation_template.html
+++ b/observation_request/templates/observation_request/create_observation_template.html
@@ -43,6 +43,9 @@
             {% endfor %}
             {% csrf_token %}
             <div class="button-container">
+                <button class="btn-secondary"
+                        type="button"
+                        onclick="window.location.href='{% url "dashboard" %}'">Cancel</button>
                 <button class="btn" type="submit">Create Observation</button>
             </div>
         </form>

--- a/observation_request/templates/observation_request/edit_observation_template.html
+++ b/observation_request/templates/observation_request/edit_observation_template.html
@@ -51,7 +51,7 @@
             <div class="button-container">
                 <button class="btn-secondary"
                         type="button"
-                        onclick="window.location.href='/'">Cancel</button>
+                        onclick="window.location.href='{% url "dashboard" %}'">Cancel</button>
                 <button class="btn" type="submit">Save changes</button>
             </div>
         </form>


### PR DESCRIPTION
Adds a "cancel" button when creating a new observation request, as requested in todays meeting.

Also: Fix an issue with the redirect on the editing page (only observable in production)