### PR TITLE
Fix table sizing behavior when text is truncated

### DIFF
--- a/accounts/templates/accounts/user_management.html
+++ b/accounts/templates/accounts/user_management.html
@@ -183,6 +183,14 @@
         <div>
             <p class="text-xl">Open Invitations</p>
             <table class="table data-table">
+                <colgroup>
+                    <col width="50%" />
+                    <col width="50%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                </colgroup>
                 <thead>
                     <tr>
                         <th class="text-align-left">Email</th>
@@ -252,6 +260,15 @@
         <div>
             <p class="text-xl">All Users</p>
             <table class="table data-table">
+                <colgroup>
+                    <col width="50%" />
+                    <col width="50%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                </colgroup>
                 <thead>
                     <tr>
                         <th class="text-align-left">Email</th>

--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -127,6 +127,21 @@
                         </button>
                     </div>
                     <table class="table observations-table">
+                        <colgroup>
+                            <col width="0%" />
+                            <col width="0%" />
+                            <col width="50%" />
+                            <col width="0%" />
+                            <col width="0%" />
+                            {% if perms.accounts.can_see_all_observations %}
+                                <col width="50%" />
+                                <col width="0%" />
+                            {% endif %}
+                            <col width="0%" />
+                            <col width="0%" />
+                            <col width="0%" />
+                            <col width="0%" />
+                        </colgroup>
                         <thead>
                             <tr>
                                 <th class="expand-row-container"></th>
@@ -253,6 +268,17 @@
                         <p class="no-completed-observations-text text">No completed observations yet.</p>
                     {% else %}
                         <table class="table observations-table">
+                            <colgroup>
+                                <col width="0%" />
+                                <col width="0%" />
+                                <col width="50%" />
+                                <col width="0%" />
+                                <col width="0%" />
+                                {% if perms.accounts.can_see_all_observations %}
+                                    <col width="50%" />
+                                {% endif %}
+                                <col width="0%" />
+                            </colgroup>
                             <thead>
                                 <tr>
                                     <th class="expand-row-container"></th>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -303,8 +303,7 @@ body::before {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
-  max-width: 0;
+  max-width: 1px;
 }
 
 .table th {


### PR DESCRIPTION
This fixes the weird issues we we're seeing before with table text getting truncated, even if it was not necessary, e.g.:

<img width="1463" alt="image" src="https://github.com/user-attachments/assets/eef556af-2b65-460a-ab6e-d63644e4e637" />

Now it is fixed... I love CSS:

https://github.com/user-attachments/assets/20e5b0cf-b286-4548-bcdb-a7e3c9601fcd

