### PR TITLE
Fix missing tooltips for truncated text (Firefox only)

### DIFF
--- a/accounts/templates/accounts/user_management.html
+++ b/accounts/templates/accounts/user_management.html
@@ -206,9 +206,12 @@
                         {% for invitation in invitations %}
                             <tr class="table-row">
                                 <td class="table-cell-truncate text-align-left"
-                                    title="{{ invitation.email }}">{{ invitation.email }}</td>
+                                    tooltip-when-truncated="{{ invitation.email }}">{{ invitation.email }}</td>
                                 {% if invitation.username != invitation.email %}
-                                    <td class="table-cell-truncate" title="{{ invitation.username }}">{{ invitation.username }}</td>
+                                    <td class="table-cell-truncate"
+                                        tooltip-when-truncated="{{ invitation.username }}">
+                                        {{ invitation.username }}
+                                    </td>
                                 {% else %}
                                     <td>-</td>
                                 {% endif %}
@@ -287,9 +290,12 @@
                             <tr id="user-{{ target_user.id }}"
                                 class="table-row {% if target_user.id == current_user.id %}table-row-highlight-current-user{% elif target_user.lifetime and target_user.lifetime < time_now %}table-row-highlight-inactive-user{% endif %}">
                                 <td class="table-cell-truncate text-align-left"
-                                    title="{{ target_user.email }}">{{ target_user.email }}</td>
+                                    tooltip-when-truncated="{{ target_user.email }}">{{ target_user.email }}</td>
                                 {% if target_user.username != target_user.email %}
-                                    <td class="table-cell-truncate" title="{{ target_user.username }}">{{ target_user.username }}</td>
+                                    <td class="table-cell-truncate"
+                                        tooltip-when-truncated="{{ target_user.username }}">
+                                        {{ target_user.username }}
+                                    </td>
                                 {% else %}
                                     <td>-</td>
                                 {% endif %}

--- a/accounts/templates/accounts/user_management.html
+++ b/accounts/templates/accounts/user_management.html
@@ -205,9 +205,10 @@
                     {% if invitations %}
                         {% for invitation in invitations %}
                             <tr class="table-row">
-                                <td class="table-cell-truncate text-align-left">{{ invitation.email }}</td>
+                                <td class="table-cell-truncate text-align-left"
+                                    title="{{ invitation.email }}">{{ invitation.email }}</td>
                                 {% if invitation.username != invitation.email %}
-                                    <td class="table-cell-truncate">{{ invitation.username }}</td>
+                                    <td class="table-cell-truncate" title="{{ invitation.username }}">{{ invitation.username }}</td>
                                 {% else %}
                                     <td>-</td>
                                 {% endif %}
@@ -285,9 +286,10 @@
                         {% if target_user.deletion_pending == False %}
                             <tr id="user-{{ target_user.id }}"
                                 class="table-row {% if target_user.id == current_user.id %}table-row-highlight-current-user{% elif target_user.lifetime and target_user.lifetime < time_now %}table-row-highlight-inactive-user{% endif %}">
-                                <td class="table-cell-truncate text-align-left">{{ target_user.email }}</td>
+                                <td class="table-cell-truncate text-align-left"
+                                    title="{{ target_user.email }}">{{ target_user.email }}</td>
                                 {% if target_user.username != target_user.email %}
-                                    <td class="table-cell-truncate">{{ target_user.username }}</td>
+                                    <td class="table-cell-truncate" title="{{ target_user.username }}">{{ target_user.username }}</td>
                                 {% else %}
                                     <td>-</td>
                                 {% endif %}

--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -314,7 +314,10 @@
                                             </div>
                                         </td>
                                         <td class="text-align-left">{{ observation.observatory.name }}</td>
-                                        <td class="text-align-left">{{ observation.target.name }}</td>
+                                        <td class="table-cell-truncate text-align-left"
+                                            tooltip-when-truncated="{{ observation.target.name }}">
+                                            {{ observation.target.name }}
+                                        </td>
                                         <td class="text-align-left">{{ observation.observation_type }}</td>
                                         <td>
                                             <div class="filter-set-container">

--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -170,7 +170,8 @@
                                         </div>
                                     </td>
                                     <td class="text-align-left">{{ observation.observatory.name }}</td>
-                                    <td class="table-cell-truncate text-align-left">{{ observation.target.name }}</td>
+                                    <td class="table-cell-truncate text-align-left"
+                                        title="{{ observation.target.name }}">{{ observation.target.name }}</td>
                                     <td class="text-align-left">{{ observation.observation_type }}</td>
                                     <td>
                                         <div class="filter-set-container">
@@ -178,7 +179,10 @@
                                         </div>
                                     </td>
                                     {% if perms.accounts.can_see_all_observations %}
-                                        <td class="table-cell-truncate text-align-right">{{ observation.user.username }}</td>
+                                        <td class="table-cell-truncate text-align-right"
+                                            title="{{ observation.user.username }}">
+                                            {{ observation.user.username }}
+                                        </td>
                                         <td class="text-align-right">{{ observation.priority }}</td>
                                     {% endif %}
                                     <td class="text-align-right">{{ observation.project_completion|floatformat:"0" }}%</td>
@@ -316,7 +320,10 @@
                                             </div>
                                         </td>
                                         {% if perms.accounts.can_see_all_observations %}
-                                            <td class="table-cell-truncate text-align-right">{{ observation.user.username }}</td>
+                                            <td class="table-cell-truncate text-align-right"
+                                                title="{{ observation.user.username }}">
+                                                {{ observation.user.username }}
+                                            </td>
                                         {% endif %}
                                         <td class="text-align-right">{{ observation.created_at|date:"d.m.Y" }}</td>
                                     </tr>

--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -214,13 +214,13 @@
                                             <i class="bx bx-edit"></i>
                                         </a>
                                         <a href="#"
-                                           onclick="delete_observation('{% url 'delete-observation' observation.id %}'); return false;"
+                                           onclick="deleteObservation('{% url 'delete-observation' observation.id %}'); return false;"
                                            title="Delete Observation"
                                            class="icon-btn">
                                             <i class="bx bx-trash"></i>
                                         </a>
                                         <a href="#"
-                                           onclick="finish_observation('{% url 'finish-observation' observation.id %}'); return false;"
+                                           onclick="finishObservation('{% url 'finish-observation' observation.id %}'); return false;"
                                            title="Finish Observation"
                                            class="icon-btn">
                                             <i class="bx bx-check"></i>
@@ -413,7 +413,7 @@
          * Sends api request to delete observation with the given id.
          * @param {string} url - The url to send the request to.
          */
-        async function delete_observation(url) {
+        async function deleteObservation(url) {
             if (await showConfirmModal("Delete Observation", "Are you sure you want to delete this observation? This action cannot be undone.", "Delete")) {
                 try {
                     const response = await fetch(url, {
@@ -437,7 +437,7 @@
             }
         }
 
-        async function finish_observation(url) {
+        async function finishObservation(url) {
             if (await showConfirmModal("Finish Observation", "Are you sure you want to mark this observation as completed?", "Finish Observation")) {
                 try {
                     const response = await fetch(url, {

--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -171,7 +171,9 @@
                                     </td>
                                     <td class="text-align-left">{{ observation.observatory.name }}</td>
                                     <td class="table-cell-truncate text-align-left"
-                                        title="{{ observation.target.name }}">{{ observation.target.name }}</td>
+                                        tooltip-when-truncated="{{ observation.target.name }}">
+                                        {{ observation.target.name }}
+                                    </td>
                                     <td class="text-align-left">{{ observation.observation_type }}</td>
                                     <td>
                                         <div class="filter-set-container">
@@ -180,7 +182,7 @@
                                     </td>
                                     {% if perms.accounts.can_see_all_observations %}
                                         <td class="table-cell-truncate text-align-right"
-                                            title="{{ observation.user.username }}">
+                                            tooltip-when-truncated="{{ observation.user.username }}">
                                             {{ observation.user.username }}
                                         </td>
                                         <td class="text-align-right">{{ observation.priority }}</td>
@@ -321,7 +323,7 @@
                                         </td>
                                         {% if perms.accounts.can_see_all_observations %}
                                             <td class="table-cell-truncate text-align-right"
-                                                title="{{ observation.user.username }}">
+                                                tooltip-when-truncated="{{ observation.user.username }}">
                                                 {{ observation.user.username }}
                                             </td>
                                         {% endif %}

--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -297,5 +297,23 @@
             </div>
         </footer>
         <script src="{% static '/js/modal.js' %}"></script>
+        <script>
+            const truncatedElements = document.querySelectorAll('.table-cell-truncate');
+            const setTitleIfTruncated = (element) => {
+                if (element.offsetWidth < element.scrollWidth) {
+                    const tooltipText = element.getAttribute('tooltip-when-truncated');
+                    if (tooltipText) {
+                        element.setAttribute('title', tooltipText);
+                    }
+                } else {
+                  element.removeAttribute('title');
+                }
+            };
+
+            truncatedElements.forEach(setTitleIfTruncated);
+            window.addEventListener('resize', () => {
+                truncatedElements.forEach(setTitleIfTruncated);
+            });
+        </script>
     </body>
 </html>

--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -300,7 +300,7 @@
         <script>
             const truncatedElements = document.querySelectorAll('.table-cell-truncate');
             const setTitleIfTruncated = (element) => {
-                if (element.offsetWidth < element.scrollWidth) {
+                if (element.clientWidth < element.scrollWidth) {
                     const tooltipText = element.getAttribute('tooltip-when-truncated');
                     if (tooltipText) {
                         element.setAttribute('title', tooltipText);


### PR DESCRIPTION
Chrome & Safari automatically show a tooltip if the text is truncated. Firefox does not...
