### PR TITLE
Allow start (scheduling) time to equal current time

### DIFF
--- a/observation_data/data_verification.py
+++ b/observation_data/data_verification.py
@@ -293,12 +293,12 @@ def validate_schedule_time(start_scheduling, end_scheduling):
     :return: Error if the time range is invalid or None if the time range is valid
     """
     errors = {}
-    if start_scheduling >= end_scheduling:
+    if start_scheduling > end_scheduling:
         errors = {
             **errors,
             "scheduling_range": "Start scheduling must be before end scheduling.",
         }
-    if start_scheduling <= timezone.now().date():
+    if start_scheduling < timezone.now().date():
         errors = {
             **errors,
             "start_scheduling": "Start scheduling must be in the future.",

--- a/observation_data/data_verification.py
+++ b/observation_data/data_verification.py
@@ -273,7 +273,7 @@ def validate_observation_time(
     if start_time >= end_time:
         errors = {**errors, "time_range": "Start time must be before end time."}
 
-    if start_time <= timezone.now():
+    if start_time < timezone.now():
         errors = {**errors, "start_time": "Start time must be in the future."}
 
     if start_time.year >= timezone.now().year + 10:

--- a/observation_data/tests.py
+++ b/observation_data/tests.py
@@ -260,6 +260,19 @@ class ObservationCreationTestCase(django.test.TestCase):
             flat=True,
         )
 
+    def test_monitoring_insert_today(self):
+        base_time = datetime.now(timezone.utc)
+        self._test_observation_insert(
+            ObservationType.MONITORING,
+            {
+                "frames_per_filter": 100,
+                "start_scheduling": base_time.date(),
+                "end_scheduling": base_time.date() + timedelta(days=2),
+                "cadence": 1,
+                "minimum_altitude": 35.0,
+            },
+        )
+
     @staticmethod
     def _get_base_expert_request():
         return {

--- a/observation_data/tests.py
+++ b/observation_data/tests.py
@@ -592,7 +592,9 @@ class ObservationCreationTestCase(django.test.TestCase):
     def test_expert_invalid_scheduling(self):
         base_time = datetime.now(timezone.utc) + timedelta(days=1)
         errors = self._test_expert_options(
-            400, start_scheduling=base_time.date(), end_scheduling=base_time.date()
+            400,
+            start_scheduling=base_time.date(),
+            end_scheduling=(base_time - timedelta(days=1)).date(),
         )
         self.assertEqual(
             errors,
@@ -615,7 +617,7 @@ class ObservationCreationTestCase(django.test.TestCase):
         errors = self._test_expert_options(
             400,
             start_scheduling=base_time.date(),
-            end_scheduling=base_time.date(),
+            end_scheduling=(base_time - timedelta(days=1)).date(),
             start_observation_time=base_time.replace(
                 hour=0, minute=0, second=0, microsecond=0
             )


### PR DESCRIPTION
This PR fixes an issue where the current date was not accepted as a possible start time